### PR TITLE
Add delete product endpoint

### DIFF
--- a/product-manager/src/main/java/ch/bbw/ap/shop/productmanager/controllers/ProductController.java
+++ b/product-manager/src/main/java/ch/bbw/ap/shop/productmanager/controllers/ProductController.java
@@ -33,4 +33,9 @@ public class ProductController {
         return ResponseEntity.ok(productService.getById(id));
     }
 
+    @DeleteMapping("/admin/products/{id}")
+    public ResponseEntity<Void> deleteProduct(@PathVariable Long id) {
+        productService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/product-manager/src/main/java/ch/bbw/ap/shop/productmanager/security/SecurityConfig.java
+++ b/product-manager/src/main/java/ch/bbw/ap/shop/productmanager/security/SecurityConfig.java
@@ -20,6 +20,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(registry ->
                         registry
                                 .requestMatchers(HttpMethod.GET, "/products/**", "/categories", "/pictures/**").permitAll()
+                                .requestMatchers(HttpMethod.DELETE, "/admin/products/**").authenticated()
                                 .requestMatchers("/error").permitAll()
                                 .anyRequest().authenticated()
                 )

--- a/product-manager/src/main/java/ch/bbw/ap/shop/productmanager/services/ProductService.java
+++ b/product-manager/src/main/java/ch/bbw/ap/shop/productmanager/services/ProductService.java
@@ -9,4 +9,5 @@ public interface ProductService {
 
     List<Product> getAll(String search, Long categoryId);
     Product getById(Long id);
+    void deleteById(Long id);
 }

--- a/product-manager/src/main/java/ch/bbw/ap/shop/productmanager/services/impl/ProductServiceImpl.java
+++ b/product-manager/src/main/java/ch/bbw/ap/shop/productmanager/services/impl/ProductServiceImpl.java
@@ -36,4 +36,9 @@ public class ProductServiceImpl implements ProductService {
 
         return product.get();
     }
+
+    @Override
+    public void deleteById(Long id) {
+        productRepository.deleteById(id);
+    }
 }


### PR DESCRIPTION
Fixes #30

Add functionality to allow an admin to delete a product using the `DELETE /admin/products/{id}` endpoint.

* Add `deleteProduct` method in `ProductController` to handle the `DELETE /admin/products/{id}` endpoint.
* Update `SecurityConfig` to allow only authenticated users to access the `DELETE /admin/products/{id}` endpoint.
* Add `deleteById` method in `ProductService` interface.
* Implement `deleteById` method in `ProductServiceImpl`.

LG Fabio

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/007anthony/m321_shop/pull/52?shareId=6ed60d92-8fd1-4230-abe4-8a62713a1786).